### PR TITLE
refactor: Change package name to py_name_entity_normalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "py-name-entity-normalization"
+name = "py_name_entity_normalization"
 version = "0.1.0"
 description = "A production-ready Python package for Named Entity Normalization (NEN) using a hybrid generate-and-rank approach with pgvector and sentence-transformers."
 authors = ["Gowtham Rao <rao@ohdsi.org>"]


### PR DESCRIPTION
Changed the package name in pyproject.toml from py-name-entity-normalization to py_name_entity_normalization to match the user's request and the existing directory structure.

The package's directory name was already `py_name_entity_normalization`, so no other changes were necessary. The test suite passes, confirming the package is working as expected with the new name.